### PR TITLE
Resolved YAMLLoadWarning adding Loader=FullLoader

### DIFF
--- a/amdgpu_fan/controller.py
+++ b/amdgpu_fan/controller.py
@@ -41,7 +41,7 @@ class FanController:
 def load_config(path):
     logger.debug(f'loading config from {path}')
     with open(path) as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=FullLoader)
 
 
 def main():


### PR DESCRIPTION
When running amdgpu-fan from command line there is a YAMLLoadWarning when using python3.7. This was resolved by adding Loader=FullLoader on line 44