### PR TITLE
Update controller.py

### DIFF
--- a/amdgpu_fan/controller.py
+++ b/amdgpu_fan/controller.py
@@ -41,7 +41,7 @@ class FanController:
 def load_config(path):
     logger.debug(f'loading config from {path}')
     with open(path) as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 def main():


### PR DESCRIPTION
It is reported that in PyYAML before 4.1, usage of yaml.load() function on untrusted input could lead to arbitrary code execution. It is therefore recommended to use yaml.safe_load() instead. With 4.1, yaml.load() has been changed to call safe_load().

* Report:          http://seclists.org/oss-sec/2018/q2/240
* Upstream change: https://github.com/yaml/pyyaml/pull/74
* CVE:             pending

--

Gentoo Security Scout
Vladimir Krstulja