### PR TITLE
Quick for for current diver bugs

### DIFF
--- a/amdgpu_fan/lib/amdgpu.py
+++ b/amdgpu_fan/lib/amdgpu.py
@@ -37,6 +37,8 @@ class Card:
             return e.read()
 
     def write_endpoint(self, endpoint, data):
+        if data >= 3:
+            data = 4
         try:
             with open(self._endpoints[endpoint], 'w') as e:
                 return e.write(str(data))

--- a/amdgpu_fan/lib/amdgpu.py
+++ b/amdgpu_fan/lib/amdgpu.py
@@ -37,8 +37,6 @@ class Card:
             return e.read()
 
     def write_endpoint(self, endpoint, data):
-        if data >= 3:
-            data = 4
         try:
             with open(self._endpoints[endpoint], 'w') as e:
                 return e.write(str(data))

--- a/amdgpu_fan/lib/curve.py
+++ b/amdgpu_fan/lib/curve.py
@@ -18,6 +18,8 @@ class Curve:
             raise ValueError(f'Fan curve points should be strictly monotonically increasing, configuration error ?')
         if np.any(np.diff(self.speeds) < 0):
             raise ValueError(f'Curve fan speeds should be monotonically increasing, configuration error ?')
+        if np.any(np.diff(self.speeds) < 0):
+            raise ValueError(f'Current driver bugs require the lowest speed value be 4')
 
     def get_speed(self, temp):
         """

--- a/amdgpu_fan/lib/curve.py
+++ b/amdgpu_fan/lib/curve.py
@@ -18,8 +18,8 @@ class Curve:
             raise ValueError(f'Fan curve points should be strictly monotonically increasing, configuration error ?')
         if np.any(np.diff(self.speeds) < 0):
             raise ValueError(f'Curve fan speeds should be monotonically increasing, configuration error ?')
-        if np.any(np.diff(self.speeds) < 0):
-            raise ValueError(f'Current driver bugs require the lowest speed value be 4')
+        if np.min(self.speeds) <= 3 :
+            raise ValueError(f'Current driver bugs require the lowest speed value be set to 4')
 
     def get_speed(self, temp):
         """

--- a/amdgpu_fan/lib/curve.py
+++ b/amdgpu_fan/lib/curve.py
@@ -18,7 +18,7 @@ class Curve:
             raise ValueError(f'Fan curve points should be strictly monotonically increasing, configuration error ?')
         if np.any(np.diff(self.speeds) < 0):
             raise ValueError(f'Curve fan speeds should be monotonically increasing, configuration error ?')
-        if np.min(self.speeds) <= 3 :
+        if np.min(self.speeds) <= 3:
             raise ValueError(f'Current driver bugs require the lowest speed value be set to 4')
 
     def get_speed(self, temp):

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -5,7 +5,7 @@ from amdgpu_fan.lib.curve import Curve
 
 class TestCurve(unittest.TestCase):
     def test_linear_curve(self):
-        curve = Curve([[0, 0], [100, 100]])
-        for speed in range(0, 100):
+        curve = Curve([[4, 4], [100, 100]])
+        for speed in range(4, 100):
             self.assertEqual(speed, curve.get_speed(speed))
 


### PR DESCRIPTION
As outlined in the post for #18 there is a current driver error causing issues with using a speed value lower than 3. 
This test should let people know to update their config with an appropriate error. 

Issue found in this thread and confirmed locally for myself. 
https://gitlab.freedesktop.org/drm/amd/-/issues/1164
