### PR TITLE
Fix for PyYAML > 5.1.0

### DIFF
--- a/amdgpu_fan/controller.py
+++ b/amdgpu_fan/controller.py
@@ -8,8 +8,6 @@ from amdgpu_fan import LOGGER as logger
 from amdgpu_fan.lib.amdgpu import Scanner
 from amdgpu_fan.lib.curve import Curve
 
-from packaging import version
-
 CONFIG_LOCATIONS = [
     '/etc/amdgpu-fan.yml',
 ]
@@ -42,10 +40,7 @@ class FanController:
 def load_config(path):
     logger.debug(f'loading config from {path}')
     with open(path) as f:
-        if version.parse(yaml.__version__) < version.parse("5.1.0"):
-            return yaml.load(f)
-        else:
-            return yaml.load(f, Loader=yaml.SafeLoader)
+        return yaml.load(f, Loader=yaml.SafeLoader)
 
 
 def main():

--- a/amdgpu_fan/controller.py
+++ b/amdgpu_fan/controller.py
@@ -8,6 +8,7 @@ from amdgpu_fan import LOGGER as logger
 from amdgpu_fan.lib.amdgpu import Scanner
 from amdgpu_fan.lib.curve import Curve
 
+from packaging import version
 
 CONFIG_LOCATIONS = [
     '/etc/amdgpu-fan.yml',
@@ -41,7 +42,10 @@ class FanController:
 def load_config(path):
     logger.debug(f'loading config from {path}')
     with open(path) as f:
-        return yaml.load(f)
+        if version.parse(yaml.__version__) < version.parse("5.1.0"):
+            return yaml.load(f)
+        else:
+            return yaml.load(f, Loader=yaml.SafeLoader)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description='amdgpu fan controller',
     long_description=readme,
     install_requires=[
-        'pyyaml',
+        'pyyaml>=5.1.0',
         'numpy',
     ],
     entry_points="""


### PR DESCRIPTION
PyYAML < 5.1.0 has exploitable security issues which were fixed by adding new loaders in 5.1.0. This change ensures PyYAML is >= 5.1.0 and uses a different loader.

Using FullLoader would be overkill so I suggest SafeLoader.

More info: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation