### PR TITLE
Add exception when running first time no root

### DIFF
--- a/amdgpu_fan/controller.py
+++ b/amdgpu_fan/controller.py
@@ -69,9 +69,14 @@ speed_matrix:
 
     if config is None:
         logger.info(f'no config found, creating one in {CONFIG_LOCATIONS[-1]}')
-        with open(CONFIG_LOCATIONS[-1], 'w') as f:
-            f.write(default_fan_config)
-            f.flush()
+        try:
+            with open(CONFIG_LOCATIONS[-1], 'w') as f:
+                f.write(default_fan_config)
+                f.flush()
+        except:
+            print(f"Failed writing to {CONFIG_LOCATIONS[-1]}, are you sure you'r running as root?")
+            logger.error('no root privileges, exiting')
+            sys.exit(1)
 
         config = load_config(CONFIG_LOCATIONS[-1])
 
@@ -80,3 +85,4 @@ speed_matrix:
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
I added a try/except block to main in controller.py because I got this error when I tried to run `amdgpu-fan` instead of `sudo amdgpu-fan` :

```python
Traceback (most recent call last):
  File "/usr/bin/amdgpu-fan", line 33, in <module>
    sys.exit(load_entry_point('amdgpu-fan==0.1.0', 'console_scripts', 'amdgpu-fan')())
  File "/usr/lib/python3.10/site-packages/amdgpu_fan/controller.py", line 89, in main
    with open(CONFIG_LOCATIONS[-1], 'w') as f:
PermissionError: [Errno 13] Permission denied: '/etc/amdgpu-fan.yml'
```